### PR TITLE
W1-2, assignment 3: Fix import statement of sampler classes

### DIFF
--- a/Week 1-2 - general intro to exploratory modelling/assignment 3 - multimodel_assignment.ipynb
+++ b/Week 1-2 - general intro to exploratory modelling/assignment 3 - multimodel_assignment.ipynb
@@ -56,7 +56,7 @@
     "from ema_workbench.connectors.excel import ExcelModel\n",
     "from ema_workbench.connectors.pysd_connector import PysdModel\n",
     "\n",
-    "from ema_workbench.em_framework.evaluators import LHS, SOBOL, MORRIS\n",
+    "from ema_workbench.em_framework.evaluators import LHSSampler, SobolSampler, MorrisSampler\n",
     "\n",
     "from ema_workbench.analysis.plotting import lines, Density\n",
     "\n",


### PR DESCRIPTION
Currently line 11 of the first cell in Assignment 3 for Week 1-2 errors, because `LHS`, `SOBOL` and `MORRIS` are variables (that are later assigned classes), not Classes themselves. This commit fixes this by renaming them to the original classes `LHSSampler`, `SobolSampler`, `MorrisSampler`.

See these assignments in [evaluators.py](https://github.com/quaquel/EMAworkbench/blob/0f2e2757804aead00ec418aae927dd3cee46ced9/ema_workbench/em_framework/evaluators.py#L83-L89).