### PR TITLE
Use f-strings for string formatting

### DIFF
--- a/Week 5-6 - robustness and direct search/figs/pareto.py
+++ b/Week 5-6 - robustness and direct search/figs/pareto.py
@@ -136,7 +136,7 @@ def intrange(arg):
     partial = []
     first = None
 
-    msg = "Could not convert {0} to index range.".format(arg)
+    msg = f"Could not convert {arg} to index range."
     err = TypeError(msg)
 
     for char in arg:
@@ -488,7 +488,7 @@ def eps_sort_solutions(tables, epsilons=None):
     if epsilons is None:
         epsilons = [1e-9] * len(objectives)
     elif len(epsilons) != nobj:
-        msg = "{0} epsilons, but {1} objectives".format(len(epsilons), nobj)
+        msg = f"{len(epsilons)} epsilons, but {nobj} objectives"
         raise SortParameterError(msg)
 
     archive = Archive(epsilons)

--- a/final assignment/dike_model_function.py
+++ b/final assignment/dike_model_function.py
@@ -78,12 +78,12 @@ class DikeNetwork(object):
                 node['rnew'] = deepcopy(node['r'])
 
                 # Initialize outcomes of interest (ooi):
-                node['losses {}'.format(s)] = []
-                node['deaths {}'.format(s)] = []
-                node['evacuation_costs {}'.format(s)] = []
+                node[f'losses {s}'] = []
+                node[f'deaths {s}'] = []
+                node[f'evacuation_costs {s}'] = []
 
             # Initialize room for the river
-            G.nodes['RfR_projects {}'.format(s)]['cost'] = 0
+            G.nodes[f'RfR_projects {s}']['cost'] = 0
         return G
 
     def progressive_height_and_costs(self, G, dikenodes, steps):  
@@ -91,28 +91,28 @@ class DikeNetwork(object):
             node = G.nodes[dike]
             # Rescale according to step and tranform in meters
             for s in steps:
-                node['DikeIncrease {}'.format(s)] *= self.dh
+                node[f'DikeIncrease {s}'] *= self.dh
                 # 1 Initialize fragility curve
                 # 2 Shift it to the degree of dike heigthening:
                 # 3 Calculate cumulative raising
-                node['fnew {}'.format(s)] = deepcopy(node['f'])
-                node['dikeh_cum {}'.format(s)] = 0
+                node[f'fnew {s}'] = deepcopy(node['f'])
+                node[f'dikeh_cum {s}'] = 0
                 
                 for ss in steps[steps <= s]:
-                    node['fnew {}'.format(s)][:, 0] += node['DikeIncrease {}'.format(ss)]                 
-                    node['dikeh_cum {}'.format(s)] += node['DikeIncrease {}'.format(ss)]
+                    node[f'fnew {s}'][:, 0] += node[f'DikeIncrease {ss}']                 
+                    node[f'dikeh_cum {s}'] += node[f'DikeIncrease {ss}']
                 
                 # Calculate dike heigheting costs:
-                if node['DikeIncrease {}'.format(s)] == 0:
-                    node['dikecosts {}'.format(s)] = 0
+                if node[f'DikeIncrease {s}'] == 0:
+                    node[f'dikecosts {s}'] = 0
                 else:
-                    node['dikecosts {}'.format(s)] = cost_fun(
+                    node[f'dikecosts {s}'] = cost_fun(
                                 node['traj_ratio'],
                                 node['c'],
                                 node['b'],
                                 node['lambda'],
-                                node['dikeh_cum {}'.format(s)],
-                                node['DikeIncrease {}'.format(s)])
+                                node[f'dikeh_cum {s}'],
+                                node[f'DikeIncrease {s}'])
 
     def __call__(self, timestep=1, **kwargs):
 
@@ -139,7 +139,7 @@ class DikeNetwork(object):
                     # (no project) or 1 (yes project)
                     temporal_step = string2.split(' ')[1]
                     
-                    proj_node = G.nodes['RfR_projects {}'.format(temporal_step)]
+                    proj_node = G.nodes[f'RfR_projects {temporal_step}']
                     # Cost of RfR project
                     proj_node['cost'] += kwargs[item] * proj_node[string1][
                         'costs_1e6'] * 1e6
@@ -183,7 +183,7 @@ class DikeNetwork(object):
                     self._initialize_hydroloads(node, time, Q_0)
                     # Calculate critical water level: water above which failure
                     # occurs
-                    node['critWL'] = Lookuplin(node['fnew {}'.format(s)], 1, 0, node['pfail'])
+                    node['critWL'] = Lookuplin(node[f'fnew {s}'], 1, 0, node['pfail'])
 
                 # Run the simulation:
                 # Run over the discharge wave:
@@ -243,22 +243,22 @@ class DikeNetwork(object):
                 # If breaches occured:
                     if node['status'][-1] == True:
                         # Losses per event:
-                        node['losses {}'.format(s)].append(Lookuplin(node['table'],
+                        node[f'losses {s}'].append(Lookuplin(node['table'],
                                                     6, 4, np.max(node['wl'])))
 
-                        node['deaths {}'.format(s)].append(Lookuplin(node['table'],
+                        node[f'deaths {s}'].append(Lookuplin(node['table'],
                                                     6, 3, np.max(node['wl'])) * (
                                     1 - G.nodes['EWS']['evacuation_percentage']))
 
-                        node['evacuation_costs {}'.format(s)].append(
+                        node[f'evacuation_costs {s}'].append(
                                 cost_evacuation(Lookuplin(
                                 node['table'], 6, 5, np.max(node['wl'])
                                 ) * G.nodes['EWS']['evacuation_percentage'],
                                 G.nodes['EWS']['DaysToThreat']))
                     else:
-                        node['losses {}'.format(s)].append(0)
-                        node['deaths {}'.format(s)].append(0)
-                        node['evacuation_costs {}'.format(s)].append(0)
+                        node[f'losses {s}'].append(0)
+                        node[f'deaths {s}'].append(0)
+                        node[f'evacuation_costs {s}'].append(0)
 
             EECosts = []
             # Iterate over the network,compute and store ooi over all events
@@ -266,26 +266,26 @@ class DikeNetwork(object):
                 node = G.nodes[dike]
 
                 # Expected Annual Damage:
-                EAD = np.trapz(node['losses {}'.format(s)], self.p_exc)
+                EAD = np.trapz(node[f'losses {s}'], self.p_exc)
                 # Discounted annual risk per dike ring:
                 disc_EAD = np.sum(discount(EAD, rate=G.nodes[
-                        'discount rate {}'.format(s)]['value'], n=self.y_step))
+                        f'discount rate {s}']['value'], n=self.y_step))
 
                 # Expected Annual number of deaths:
-                END = np.trapz(node['deaths {}'.format(s)], self.p_exc)
+                END = np.trapz(node[f'deaths {s}'], self.p_exc)
 
                 # Expected Evacuation costs: depend on the event, the higher
                 # the event, the more people you have got to evacuate:
-                EECosts.append(np.trapz(node['evacuation_costs {}'.format(s)], self.p_exc))
+                EECosts.append(np.trapz(node[f'evacuation_costs {s}'], self.p_exc))
 
-                data.update({'{}_Expected Annual Damage {}'.format(dike,s): disc_EAD,
-                         '{}_Expected Number of Deaths {}'.format(dike,s): END,
+                data.update({f'{dike}_Expected Annual Damage {s}': disc_EAD,
+                         f'{dike}_Expected Number of Deaths {s}': END,
                          '{}_Dike Investment Costs {}'.format(dike,s
-                                              ): node['dikecosts {}'.format(s)]})
+                                              ): node[f'dikecosts {s}']})
 
-            data.update({'RfR Total Costs {}'.format(s): G.nodes[
-                                'RfR_projects {}'.format(s)]['cost'.format(s)]})
-            data.update({'Expected Evacuation Costs {}'.format(s): np.sum(EECosts)})
+            data.update({f'RfR Total Costs {s}': G.nodes[
+                                f'RfR_projects {s}']['cost'.format(s)]})
+            data.update({f'Expected Evacuation Costs {s}': np.sum(EECosts)})
 
         return data
 

--- a/final assignment/dike_model_simulation.py
+++ b/final assignment/dike_model_simulation.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     # Build a user-defined scenario and policy:
     reference_values = {'Bmax': 175, 'Brate': 1.5, 'pfail': 0.5,
                         'ID flood wave shape': 4, 'planning steps': 2}
-    reference_values.update({'discount rate {}'.format(n): 3.5 for n in planning_steps})
+    reference_values.update({f'discount rate {n}': 3.5 for n in planning_steps})
     scen1 = {}
 
     for key in dike_model.uncertainties:
@@ -36,8 +36,8 @@ if __name__ == '__main__':
 
     # no dike increase, no warning, none of the rfr
     zero_policy = {'DaysToThreat': 0}
-    zero_policy.update({'DikeIncrease {}'.format(n): 0 for n in planning_steps})
-    zero_policy.update({'RfR {}'.format(n): 0 for n in planning_steps})
+    zero_policy.update({f'DikeIncrease {n}': 0 for n in planning_steps})
+    zero_policy.update({f'RfR {n}': 0 for n in planning_steps})
     pol0 = {}
 
     for key in dike_model.levers:

--- a/final assignment/funs_generate_network.py
+++ b/final assignment/funs_generate_network.py
@@ -46,10 +46,10 @@ def get_network(plann_steps_max=10):
     for n in steps:
         a = to_dict_dropna(projects)
         
-        G.add_node('RfR_projects {}'.format(n), **a)
-        G.nodes['RfR_projects {}'.format(n)]['type'] = 'measure'
+        G.add_node(f'RfR_projects {n}', **a)
+        G.nodes[f'RfR_projects {n}']['type'] = 'measure'
 
-        G.add_node('discount rate {}'.format(n), **{'value': 0})
+        G.add_node(f'discount rate {n}', **{'value': 0})
 
     # Upload evacuation policies:
     G.add_node('EWS', **pd.read_excel('./data/EWS.xlsx').to_dict())
@@ -73,11 +73,11 @@ def get_network(plann_steps_max=10):
         G.nodes[dike]['dikelevel'] = Lookuplin(G.nodes[dike]['f'], 1, 0, 0.5)
 
         # Assign stage-discharge relationships
-        filename = './data/rating_curves/{}_ratingcurve_new.txt'.format(dike)
+        filename = f'./data/rating_curves/{dike}_ratingcurve_new.txt'
         G.nodes[dike]['r'] = np.loadtxt(filename)
 
         # Assign losses per location:
-        name = './data/losses_tables/{}_lossestable.xlsx'.format(dike)
+        name = f'./data/losses_tables/{dike}_lossestable.xlsx'
         G.nodes[dike]['table'] = pd.read_excel(name, index_col=0).values
 
         # Assign Muskingum paramters:

--- a/final assignment/problem_formulation.py
+++ b/final assignment/problem_formulation.py
@@ -28,7 +28,7 @@ def get_model_for_problem_formulation(problem_formulation_id):
     # breach growth rate [m/day]
     cat_uncert_loc = {'Brate': (1., 1.5, 10)}
 
-    cat_uncert = {'discount rate {}'.format(n): (1.5, 2.5, 3.5, 4.5)
+    cat_uncert = {f'discount rate {n}': (1.5, 2.5, 3.5, 4.5)
                     for n in function.planning_steps}
     
     Int_uncert = {'A.0_ID flood wave shape': [0, 132]}
@@ -36,7 +36,7 @@ def get_model_for_problem_formulation(problem_formulation_id):
     dike_lev = {'DikeIncrease': [0, 10]}    # dm
 
     # Series of five Room for the River projects:
-    rfr_lev = ['{}_RfR'.format(project_id) for project_id in range(0, 5)]
+    rfr_lev = [f'{project_id}_RfR' for project_id in range(0, 5)]
 
     # Time of warning: 0, 1, 2, 3, 4 days ahead from the flood
     EWS_lev = {'EWS_DaysToThreat': [0, 4]}  # days
@@ -56,7 +56,7 @@ def get_model_for_problem_formulation(problem_formulation_id):
     # RfR levers can be either 0 (not implemented) or 1 (implemented)
     for lev_name in rfr_lev:
         for n in function.planning_steps:
-            lev_name_ = '{} {}'.format(lev_name, n)
+            lev_name_ = f'{lev_name} {n}'
             levers.append(IntegerParameter(lev_name_, 0, 1))
 
     # Early Warning System lever
@@ -67,19 +67,19 @@ def get_model_for_problem_formulation(problem_formulation_id):
     for dike in function.dikelist:
         # uncertainties in the form: locationName_uncertaintyName
         for uncert_name in Real_uncert.keys():
-            name = "{}_{}".format(dike, uncert_name)
+            name = f"{dike}_{uncert_name}"
             lower, upper = Real_uncert[uncert_name]
             uncertainties.append(RealParameter(name, lower, upper))
 
         for uncert_name in cat_uncert_loc.keys():
-            name = "{}_{}".format(dike, uncert_name)
+            name = f"{dike}_{uncert_name}"
             categories = cat_uncert_loc[uncert_name]
             uncertainties.append(CategoricalParameter(name, categories))
 
         # location-related levers in the form: locationName_leversName
         for lev_name in dike_lev.keys():
             for n in function.planning_steps:
-                name = "{}_{} {}".format(dike, lev_name, n)
+                name = f"{dike}_{lev_name} {n}"
                 levers.append(IntegerParameter(name, dike_lev[lev_name][0],
                                            dike_lev[lev_name][1]))
 
@@ -99,15 +99,15 @@ def get_model_for_problem_formulation(problem_formulation_id):
         for n in function.planning_steps:
             
             variable_names.extend(
-                ['{}_{} {}'.format(dike, e, n) for e in [
+                [f'{dike}_{e} {n}' for e in [
                   'Expected Annual Damage', 'Dike Investment Costs'] for dike in function.dikelist])
 
             variable_names_.extend(
-                ['{}_{} {}'.format(dike, e, n) for e in [
+                [f'{dike}_{e} {n}' for e in [
                   'Expected Number of Deaths'] for dike in function.dikelist])
     
-            variable_names.extend(['RfR Total Costs {}'.format(n)])
-            variable_names.extend(['Expected Evacuation Costs {}'.format(n)])
+            variable_names.extend([f'RfR Total Costs {n}'])
+            variable_names.extend([f'Expected Evacuation Costs {n}'])
 
         dike_model.outcomes = [ScalarOutcome('All Costs',
                                              variable_name=[
@@ -125,15 +125,15 @@ def get_model_for_problem_formulation(problem_formulation_id):
         variable_names__ = []
         
         for n in function.planning_steps:
-            variable_names.extend(['{}_Expected Annual Damage {}'.format(dike, n)
+            variable_names.extend([f'{dike}_Expected Annual Damage {n}'
                                          for dike in function.dikelist])
     
-            variable_names_.extend(['{}_Dike Investment Costs {}'.format(dike, n)
+            variable_names_.extend([f'{dike}_Dike Investment Costs {n}'
                                     for dike in function.dikelist] + [
-                                  'RfR Total Costs {}'.format(n)
-                                   ] + ['Expected Evacuation Costs {}'.format(n)])
+                                  f'RfR Total Costs {n}'
+                                   ] + [f'Expected Evacuation Costs {n}'])
     
-            variable_names__.extend(['{}_Expected Number of Deaths {}'.format(dike, n)
+            variable_names__.extend([f'{dike}_Expected Number of Deaths {n}'
                                          for dike in function.dikelist])
 
             
@@ -159,13 +159,13 @@ def get_model_for_problem_formulation(problem_formulation_id):
         variable_names____ = []
         
         for n in function.planning_steps:
-            variable_names.extend(['{}_Expected Annual Damage {}'.format(dike, n)
+            variable_names.extend([f'{dike}_Expected Annual Damage {n}'
                                          for dike in function.dikelist])
-            variable_names_.extend(['{}_Dike Investment Costs {}'.format(dike, n)
+            variable_names_.extend([f'{dike}_Dike Investment Costs {n}'
                                       for dike in function.dikelist])
-            variable_names__.extend(['RfR Total Costs {}'.format(n)])       
-            variable_names___.extend(['Expected Evacuation Costs {}'.format(n)])
-            variable_names____.extend(['{}_Expected Number of Deaths {}'.format(dike, n)
+            variable_names__.extend([f'RfR Total Costs {n}'])       
+            variable_names___.extend([f'Expected Evacuation Costs {n}'])
+            variable_names____.extend([f'{dike}_Expected Number of Deaths {n}'
                                          for dike in function.dikelist])
 
         dike_model.outcomes = [
@@ -196,14 +196,14 @@ def get_model_for_problem_formulation(problem_formulation_id):
         for dike in function.dikelist:
             variable_name = []
             for e in ['Expected Annual Damage', 'Dike Investment Costs']:
-                variable_name.extend(['{}_{} {}'.format(dike, e, n)
+                variable_name.extend([f'{dike}_{e} {n}'
                                           for n in function.planning_steps])
             
-            outcomes.append(ScalarOutcome('{} Total Costs'.format(dike),
+            outcomes.append(ScalarOutcome(f'{dike} Total Costs',
                                           variable_name=[var for var in variable_name],
                                           function=sum_over, kind=direction))
 
-            outcomes.append(ScalarOutcome('{}_Expected Number of Deaths'.format(dike),
+            outcomes.append(ScalarOutcome(f'{dike}_Expected Number of Deaths',
                                           variable_name=['{}_Expected Number of Deaths {}'.format(
                                                   dike, n) for n in function.planning_steps],
                                           function=sum_over, kind=direction))
@@ -226,24 +226,24 @@ def get_model_for_problem_formulation(problem_formulation_id):
         for n in function.planning_steps:
             for dike in function.dikelist:
     
-                outcomes.append(ScalarOutcome('Expected Annual Damage {}'.format(n),
-                                variable_name=['{}_Expected Annual Damage {}'.format(dike,n)
+                outcomes.append(ScalarOutcome(f'Expected Annual Damage {n}',
+                                variable_name=[f'{dike}_Expected Annual Damage {n}'
                                                 for dike in function.dikelist],
                                 function=sum_over, kind=direction))
             
-                outcomes.append(ScalarOutcome('Dike Investment Costs {}'.format(n),
-                                variable_name=['{}_Dike Investment Costs {}'.format(dike,n)
+                outcomes.append(ScalarOutcome(f'Dike Investment Costs {n}',
+                                variable_name=[f'{dike}_Dike Investment Costs {n}'
                                                 for dike in function.dikelist],
                                           function=sum_over, kind=direction))
 
-                outcomes.append(ScalarOutcome('Expected Number of Deaths {}'.format(n),
-                               variable_name=['{}_Expected Number of Deaths {}'.format(dike,n)
+                outcomes.append(ScalarOutcome(f'Expected Number of Deaths {n}',
+                               variable_name=[f'{dike}_Expected Number of Deaths {n}'
                                                 for dike in function.dikelist],
                                           function=sum_over, kind=direction))
 
-            outcomes.append(ScalarOutcome('RfR Total Costs {}'.format(n),
+            outcomes.append(ScalarOutcome(f'RfR Total Costs {n}',
                                           kind=direction))
-            outcomes.append(ScalarOutcome('Expected Evacuation Costs {}'.format(n),
+            outcomes.append(ScalarOutcome(f'Expected Evacuation Costs {n}',
                                           kind=direction))
 
         dike_model.outcomes = outcomes
@@ -257,11 +257,11 @@ def get_model_for_problem_formulation(problem_formulation_id):
                 for entry in ['Expected Annual Damage', 'Dike Investment Costs',
                           'Expected Number of Deaths']:
                     
-                    o = ScalarOutcome('{}_{} {}'.format(dike, entry, n), kind=direction)
+                    o = ScalarOutcome(f'{dike}_{entry} {n}', kind=direction)
                     outcomes.append(o)
 
-            outcomes.append(ScalarOutcome('RfR Total Costs {}'.format(n), kind=direction))
-            outcomes.append(ScalarOutcome('Expected Evacuation Costs {}'.format(n), kind=direction))
+            outcomes.append(ScalarOutcome(f'RfR Total Costs {n}', kind=direction))
+            outcomes.append(ScalarOutcome(f'Expected Evacuation Costs {n}', kind=direction))
         dike_model.outcomes = outcomes
         
     else:


### PR DESCRIPTION
Reformats all the text from the old "%-formatted" and .format(...) format to the newer f-string format, as defined in [PEP 498](https://www.python.org/dev/peps/pep-0498/). This requires Python 3.6+.

[Flynt](https://github.com/ikamensh/flynt) 0.76 was used to reformat the strings. 78 f-strings were created in 5 files.

F-strings are in general more readable, concise and performant. See also: [PEP 498#Rationale](https://www.python.org/dev/peps/pep-0498/#rationale)

```
Running flynt v.0.76

Flynt run has finished. Stats:

Execution time:                            0.509s
Files checked:                             15
Files modified:                            5
Character count reduction:                 672 (0.92%)

Per expression type:
No old style (`%`) expressions attempted.
`.format(...)` calls attempted:            82/83 (98.8%)
No concatenations attempted.
F-string expressions created:              78
```