### PR TITLE
Update dike_model_function.py

### DIFF
--- a/final assignment/dike_model_function.py
+++ b/final assignment/dike_model_function.py
@@ -289,4 +289,5 @@ class DikeNetwork(object):
                                 f'RfR_projects {s}']['cost'.format(s)]})
             data.update({f'Expected Evacuation Costs {s}': np.sum(EECosts)})
 
+        data = {k:float(v) for k, v in data.items()}
         return data


### PR DESCRIPTION
Fixes "KeyError: 'Dike Investment Costs'" and "ValueError: cannot convert float NaN to integer" when no levers are activated