### PR TITLE
funs_dikes.py: Speedup linear interpolation with NumPy (3.9x model speedup)

### DIFF
--- a/final assignment/funs_dikes.py
+++ b/final assignment/funs_dikes.py
@@ -60,23 +60,7 @@ def dikefailure(sb, inflow, hriver, hbas, hground, status_t1,
 
 def Lookuplin(MyFile, inputcol, searchcol, inputvalue):
     ''' Linear lookup function '''
-
-    minTableValue = np.min(MyFile[:, inputcol])
-    maxTableValue = np.max(MyFile[:, inputcol])
-
-    if inputvalue >= maxTableValue:
-        inputvalue = maxTableValue - 0.01
-    elif inputvalue < minTableValue:
-        inputvalue = minTableValue + 0.01
-
-    A = np.max(MyFile[MyFile[:, inputcol] <= inputvalue, inputcol])
-    B = np.min(MyFile[MyFile[:, inputcol] > inputvalue, inputcol])
-    C = np.max(MyFile[MyFile[:, inputcol] == A, searchcol])
-    D = np.min(MyFile[MyFile[:, inputcol] == B, searchcol])
-
-    outpuvalue = C - ((D - C) * ((inputvalue - A) / (A - B))) * 1.0
-
-    return outpuvalue
+    return np.interp(inputvalue, MyFile[:, inputcol], MyFile[:, searchcol])
 
 
 def init_node(value, time):

--- a/final assignment/funs_generate_network.py
+++ b/final assignment/funs_generate_network.py
@@ -73,8 +73,9 @@ def get_network(plann_steps_max=10):
         G.nodes[dike]['dikelevel'] = Lookuplin(G.nodes[dike]['f'], 1, 0, 0.5)
 
         # Assign stage-discharge relationships
-        filename = f'./data/rating_curves/{dike}_ratingcurve_new.txt'
-        G.nodes[dike]['r'] = np.loadtxt(filename)
+        filename = f'./data/rating_curves/{dike}_ratingcurve_new.txt'   # Load file
+        rc_array = np.loadtxt(filename)                                 # Load file into array
+        G.nodes[dike]['r'] = rc_array[rc_array[:,0].argsort()]          # Sort on first column before saving
 
         # Assign losses per location:
         name = f'./data/losses_tables/{dike}_lossestable.xlsx'


### PR DESCRIPTION
### Summary
Speed up the model by approximately a factor 3.9 by using [`NumPy.interp()`](https://numpy.org/doc/stable/reference/generated/numpy.interp.html) for linear interpolation instead of the custom defined Python function.

### Motivation
A faster model evaluation helps test more policies and scenarios in a shorter amount of time, allowing for more accurate results, more extreme value testing and quicker iteration time.

### Performance
The linear lookup function in plain Python code takes up around 80% of the runtime on evaluation of the dike model. Speeding up this function was the most likely candidate to make the model significantly faster.

Two approaches were considered, both using built-in functions of popular libaries:

- NumPy is a highly optimized computing library, with practically all functions implemented in C code and in many cases highly vectorized, allowing to use SIMD operations which improve performance especially on processors that support AVX2, AVX512 or NEON.
- SciPy was also tested, since it's a leading scientific computing library. The SciPy function was as follows:
  ```Python
  def Lookuplin(MyFile, inputcol, searchcol, inputvalue):
      ''' Linear lookup function '''
      bounds = (MyFile[:, searchcol].min(), MyFile[:, searchcol].max())
      lookup_function = interp1d(MyFile[:, inputcol], MyFile[:, searchcol], kind='linear', fill_value=bounds, bounds_error=False)
      return lookup_function(inputvalue)
  ```
All three functions were benchmarked by running the `perform_experiments()` function 10 times using the  `SequentialEvaluator` from the EMAworkbench.
```Python
with SequentialEvaluator(dike_model) as evaluator:
    evaluator.perform_experiments(scenarios=10, policies=1)
```
This code blok was ran 25 times for each linear lookup function, and the run times for each run were saved. The results are shown in the boxplot below:
![linear_lookup_performance_boxplot](https://user-images.githubusercontent.com/15776622/174474302-f3f318b8-1ff9-446a-85c1-676cda06d9b9.svg)

The NumPy function turned out to be on average 3.9x faster (on an Intel [Core i5-4590](https://www.intel.com/content/www/us/en/products/sku/80815/intel-core-i54590-processor-6m-cache-up-to-3-70-ghz/specifications.html)). As viewable from the boxplot, there is little variation among the runs and the performance difference was very significant.

To reproduce or improve upon, the benchmark code is available in `linlookup_perf_test.py` and the notebook the generate the boxplot and save the results in `linlookup_analysis.ipynb`. Both are available in this ZIP file: [linear_lookup_performance_code.zip](https://github.com/quaquel/epa1361_open/files/8935090/linear_lookup_performance_code.zip)

The results are also available here for further analysis [linlookup_benchmark_results.csv](https://github.com/quaquel/epa1361_open/files/8935067/linlookup_benchmark_results.csv).

### Validation
The NumPy linear lookup function is fully validated against the old behaviour and against [`scipy.interpolate.interp1d()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html). It even makes values on the edges of bounds a bit more accurate, since the 0.01 isn't added or subtracted if a out-of-bounds value is detected.

The NumPy default behaviour with out-of-bounds lookups is to return the maximum of minimum value of the lookup array, and thus clip the range of return values to the lookup array itself. This is exactly what the current Python function does. However, if this is desirable behaviour can be discussed in the future.

Note, that by removing the +- 0.01, the out-of-bounds values change slightly, and thus the model outcomes aren't exactly identical. In some cases, where the input values were very low, adding the +0.01 created a difference between 3% and 4% to the return value. So by removing this arbitrarily constant, it makes the model more accurate by removing that arbitrarily constant.

All code used for validation can be found in this commit: https://github.com/EwoutH/modelbased-g13/commit/9dae5da5e754d87e54b4a55cabf70f840788950d. It calculates the linear lookup using the current, NumPy and SciPy method, and compares the results. If the returned NumPy values differ more than 0.1% from the current behaviour, the exact values of all three values are printed, and a breakpoint is triggered to allow for manual inspection.

### Additional potential improvements
The accuracy of the model could be generally improved by making sure the lookup arrays span a wide enough range to cover all probable lookup values. This is out of the scope of this effort, however.

### Limitations & mitigation
Note that the new linear lookup function expects a sorted array as input. Unsorted arrays will return invalid results. Therefore, the rating curves are now sorted when the network is generated in `funs_generate_network.py`.

### Related issue
Closes #8.